### PR TITLE
Handle export errors with codes

### DIFF
--- a/templates_service.py
+++ b/templates_service.py
@@ -68,6 +68,25 @@ else:
 
 OPENPYXL_AVAILABLE = Workbook is not None
 
+
+class ExportError(RuntimeError):
+    """Custom exception describing export failures."""
+
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+    def __str__(self):  # pragma: no cover - mirrors base behaviour
+        return self.message
+
+
+EXPORT_ERR_NO_OPENPYXL = "NO_OPENPYXL"
+EXPORT_ERR_FOLDER_PREP = "FOLDER_PREP_FAILED"
+EXPORT_ERR_PERMISSION = "PERMISSION_DENIED"
+EXPORT_ERR_OS_ERROR = "OS_ERROR"
+EXPORT_ERR_UNKNOWN_FORMAT = "UNKNOWN_FORMAT"
+
 if EXCEL_EXPORT_BLOCKED_MESSAGE:
     detail_suffix = (
         f"\nДеталі: {OPENPYXL_IMPORT_ERROR_DETAIL}" if OPENPYXL_IMPORT_ERROR_DETAIL else ""
@@ -1264,7 +1283,11 @@ def _make_unique_column_keys(columns):
 
 def ensure_folder(path: str):
     if path and not os.path.exists(path):
-        os.makedirs(path, exist_ok=True)
+        try:
+            os.makedirs(path, exist_ok=True)
+        except OSError as exc:
+            message = f"Не вдалося підготувати теку для експорту: {exc}"
+            raise ExportError(EXPORT_ERR_FOLDER_PREP, message) from exc
 
 
 def export_products(records: list, columns: list, fmt: str, folder: str):
@@ -1279,7 +1302,7 @@ def export_products(records: list, columns: list, fmt: str, folder: str):
             if detail and detail not in message:
                 message = f"{message} (деталі: {detail})"
             message = f"{message}\n{OPENPYXL_INSTALL_HINT}{CSV_JSON_FALLBACK_NOTE}"
-            raise RuntimeError(message)
+            raise ExportError(EXPORT_ERR_NO_OPENPYXL, message)
 
         out_products = base + ".xlsx"
         workbook = Workbook()
@@ -1299,10 +1322,10 @@ def export_products(records: list, columns: list, fmt: str, folder: str):
             message = (
                 "Не вдалося зберегти Excel-файл: доступ заборонено. Закрийте файл, якщо він відкритий, та спробуйте знову."
             )
-            raise RuntimeError(message) from exc
+            raise ExportError(EXPORT_ERR_PERMISSION, message) from exc
         except OSError as exc:  # pragma: no cover - defensive
             message = f"Не вдалося зберегти Excel-файл: {exc}"
-            raise RuntimeError(message) from exc
+            raise ExportError(EXPORT_ERR_OS_ERROR, message) from exc
         finally:
             try:
                 workbook.close()
@@ -1310,13 +1333,22 @@ def export_products(records: list, columns: list, fmt: str, folder: str):
                 pass
     elif fmt == CSV_FORMAT_LABEL:
         out_products = base + ".csv"
-        with open(out_products, "w", newline="", encoding="utf-8-sig") as f:
-            writer = csv.writer(f)
-            if columns:
-                writer.writerow(columns)
-            for record in records:
-                row = _row_to_values(record, columns)
-                writer.writerow(row)
+        try:
+            with open(out_products, "w", newline="", encoding="utf-8-sig") as f:
+                writer = csv.writer(f)
+                if columns:
+                    writer.writerow(columns)
+                for record in records:
+                    row = _row_to_values(record, columns)
+                    writer.writerow(row)
+        except PermissionError as exc:
+            message = (
+                "Не вдалося зберегти CSV-файл: доступ заборонено. Закрийте файл, якщо він відкритий, та спробуйте знову."
+            )
+            raise ExportError(EXPORT_ERR_PERMISSION, message) from exc
+        except OSError as exc:
+            message = f"Не вдалося зберегти CSV-файл: {exc}"
+            raise ExportError(EXPORT_ERR_OS_ERROR, message) from exc
     elif fmt == JSON_FORMAT_LABEL:
         out_products = base + ".json"
         json_records = []
@@ -1324,9 +1356,19 @@ def export_products(records: list, columns: list, fmt: str, folder: str):
         for record in records:
             values = _row_to_values(record, columns)
             json_records.append({key: value for key, value in zip(json_columns, values)})
-        with open(out_products, "w", encoding="utf-8") as f:
-            json.dump(json_records, f, ensure_ascii=False, indent=2)
+        try:
+            with open(out_products, "w", encoding="utf-8") as f:
+                json.dump(json_records, f, ensure_ascii=False, indent=2)
+        except PermissionError as exc:
+            message = (
+                "Не вдалося зберегти JSON-файл: доступ заборонено. Закрийте файл, якщо він відкритий, та спробуйте знову."
+            )
+            raise ExportError(EXPORT_ERR_PERMISSION, message) from exc
+        except OSError as exc:
+            message = f"Не вдалося зберегти JSON-файл: {exc}"
+            raise ExportError(EXPORT_ERR_OS_ERROR, message) from exc
     else:
-        raise ValueError(f"Невідомий формат експорту: {fmt}")
+        message = f"Невідомий формат експорту: {fmt}"
+        raise ExportError(EXPORT_ERR_UNKNOWN_FORMAT, message)
 
     return out_products

--- a/tests/test_app_generate.py
+++ b/tests/test_app_generate.py
@@ -1,0 +1,150 @@
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# Provide lightweight stubs for optional GUI/dependency modules.
+jinja2_stub = types.ModuleType("jinja2")
+jinja2_stub.Template = object
+jinja2_stub.TemplateError = Exception
+sys.modules.setdefault("jinja2", jinja2_stub)
+
+
+class _Widget:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def pack(self, *args, **kwargs):
+        return None
+
+    def grid(self, *args, **kwargs):
+        return None
+
+    def place(self, *args, **kwargs):
+        return None
+
+    def configure(self, *args, **kwargs):
+        return None
+
+    def bind(self, *args, **kwargs):
+        return None
+
+    def destroy(self, *args, **kwargs):
+        return None
+
+
+class _CTkFont:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+ctk_stub = types.ModuleType("customtkinter")
+ctk_stub.CTk = type("CTk", (_Widget,), {})
+ctk_stub.CTkToplevel = type("CTkToplevel", (_Widget,), {})
+ctk_stub.CTkFrame = type("CTkFrame", (_Widget,), {})
+ctk_stub.CTkEntry = type("CTkEntry", (_Widget,), {})
+ctk_stub.CTkButton = type("CTkButton", (_Widget,), {})
+ctk_stub.CTkLabel = type("CTkLabel", (_Widget,), {})
+ctk_stub.CTkOptionMenu = type("CTkOptionMenu", (_Widget,), {})
+ctk_stub.CTkTextbox = type("CTkTextbox", (_Widget,), {})
+ctk_stub.CTkTabview = type("CTkTabview", (_Widget,), {})
+ctk_stub.CTkProgressBar = type("CTkProgressBar", (_Widget,), {})
+ctk_stub.CTkCheckBox = type("CTkCheckBox", (_Widget,), {})
+ctk_stub.CTkFont = _CTkFont
+ctk_stub.BooleanVar = type("BooleanVar", (), {"__init__": lambda self, *a, **k: None})
+ctk_stub.get_appearance_mode = lambda: "light"
+ctk_stub.set_appearance_mode = lambda mode: None
+ctk_stub.set_default_color_theme = lambda theme: None
+
+sys.modules.setdefault("customtkinter", ctk_stub)
+
+import ui.app as app_module
+from templates_service import ExportError, EXCEL_FORMAT_LABEL
+
+
+class DummyVar:
+    def __init__(self, value):
+        self._value = value
+
+    def get(self):
+        return self._value
+
+    def set(self, value):
+        self._value = value
+
+
+@pytest.fixture
+def prepared_app(monkeypatch, tmp_path):
+    app = app_module.App.__new__(app_module.App)
+
+    # Stubs for progress reporting and persistence
+    app._progress_reset = lambda *args, **kwargs: None
+    app._progress_message = lambda *args, **kwargs: None
+    app._progress_update = lambda *args, **kwargs: None
+    app._progress_finish = lambda *args, **kwargs: None
+    app._save_title_tags = lambda *args, **kwargs: None
+    app._export_apply_detail = lambda *args, **kwargs: None
+
+    app.ft_vars = [("TypeA", types.SimpleNamespace(get=lambda: True))]
+    app.templates = {"film_types": [{"name": "TypeA", "enabled": True}]}
+    app.title_tags_templates = {}
+    app.export_fields = []
+    app.export_language_vars = []
+    app._collect_checked_model_ids = types.MethodType(lambda self: [], app)
+    app._collect_selected_export_languages = types.MethodType(lambda self: [], app)
+    app._template_language_codes = types.MethodType(lambda self: [], app)
+
+    app.export_fmt_var = DummyVar(EXCEL_FORMAT_LABEL)
+    app.out_folder_var = DummyVar(str(tmp_path))
+
+    monkeypatch.setattr(app_module, "save_templates", lambda templates: None)
+    monkeypatch.setattr(
+        app_module,
+        "generate_export_rows",
+        lambda *args, **kwargs: ([{"col": "value"}], ["col"]),
+    )
+
+    return app
+
+
+def test_generate_shows_export_error_code(monkeypatch, prepared_app):
+    messages = []
+
+    def fake_show_error(message):
+        messages.append(message)
+        return message
+
+    monkeypatch.setattr(app_module, "show_error", fake_show_error)
+    monkeypatch.setattr(app_module, "show_info", lambda message: None)
+
+    def failing_export(*args, **kwargs):
+        raise ExportError("TEST_CODE", "details")
+
+    monkeypatch.setattr(app_module, "export_products", failing_export)
+
+    prepared_app._generate()
+
+    assert messages == ["Помилка експорту (код TEST_CODE): details"]
+
+
+def test_generate_unexpected_exception_uses_fallback(monkeypatch, prepared_app):
+    messages = []
+
+    def fake_show_error(message):
+        messages.append(message)
+        return message
+
+    monkeypatch.setattr(app_module, "show_error", fake_show_error)
+    monkeypatch.setattr(app_module, "show_info", lambda message: None)
+
+    def failing_export(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(app_module, "export_products", failing_export)
+
+    prepared_app._generate()
+
+    assert messages == ["Не вдалося зберегти файли: boom"]

--- a/tests/test_templates_service_export.py
+++ b/tests/test_templates_service_export.py
@@ -1,0 +1,107 @@
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+jinja2_stub = types.ModuleType("jinja2")
+jinja2_stub.Template = object
+jinja2_stub.TemplateError = Exception
+sys.modules.setdefault("jinja2", jinja2_stub)
+
+import templates_service as ts
+
+
+class DummySheet:
+    def __init__(self):
+        self.rows = []
+        self.title = ""
+
+    def append(self, row):
+        self.rows.append(tuple(row))
+
+
+class DummyWorkbook:
+    def __init__(self, save_exc):
+        self.active = DummySheet()
+        self._save_exc = save_exc
+        self.closed = False
+
+    def save(self, filename):
+        raise self._save_exc
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture
+def excel_context(monkeypatch):
+    monkeypatch.setattr(ts, "OPENPYXL_AVAILABLE", True)
+    monkeypatch.setattr(ts, "EXCEL_EXPORT_BLOCKED_MESSAGE", "")
+    monkeypatch.setattr(ts, "OPENPYXL_IMPORT_ERROR_DETAIL", "")
+
+
+def test_export_products_missing_dependency(monkeypatch, tmp_path):
+    monkeypatch.setattr(ts, "OPENPYXL_AVAILABLE", False)
+    monkeypatch.setattr(ts, "EXCEL_EXPORT_BLOCKED_MESSAGE", "")
+    monkeypatch.setattr(ts, "OPENPYXL_IMPORT_ERROR_DETAIL", "")
+
+    with pytest.raises(ts.ExportError) as excinfo:
+        ts.export_products([], [], ts.EXCEL_FORMAT_LABEL, str(tmp_path))
+
+    assert excinfo.value.code == ts.EXPORT_ERR_NO_OPENPYXL
+    assert "Експорт у Excel" in excinfo.value.message
+
+
+def test_export_products_permission_error(monkeypatch, tmp_path, excel_context):
+    def make_workbook():
+        return DummyWorkbook(PermissionError("denied"))
+
+    monkeypatch.setattr(ts, "Workbook", make_workbook)
+
+    with pytest.raises(ts.ExportError) as excinfo:
+        ts.export_products([["value"]], ["col"], ts.EXCEL_FORMAT_LABEL, str(tmp_path))
+
+    assert excinfo.value.code == ts.EXPORT_ERR_PERMISSION
+    assert "доступ заборонено" in excinfo.value.message
+
+
+def test_export_products_os_error(monkeypatch, tmp_path, excel_context):
+    def make_workbook():
+        return DummyWorkbook(OSError("disk full"))
+
+    monkeypatch.setattr(ts, "Workbook", make_workbook)
+
+    with pytest.raises(ts.ExportError) as excinfo:
+        ts.export_products([["value"]], ["col"], ts.EXCEL_FORMAT_LABEL, str(tmp_path))
+
+    assert excinfo.value.code == ts.EXPORT_ERR_OS_ERROR
+    assert "disk full" in excinfo.value.message
+
+
+def test_export_products_unknown_format():
+    with pytest.raises(ts.ExportError) as excinfo:
+        ts.export_products([], [], "custom", ".")
+
+    assert excinfo.value.code == ts.EXPORT_ERR_UNKNOWN_FORMAT
+
+
+def test_export_products_folder_preparation_failure(monkeypatch, tmp_path):
+    target = tmp_path / "nested"
+
+    def fake_exists(path):
+        return False
+
+    def fake_makedirs(path, exist_ok=True):
+        raise OSError("cannot create directory")
+
+    monkeypatch.setattr(ts.os.path, "exists", fake_exists)
+    monkeypatch.setattr(ts.os, "makedirs", fake_makedirs)
+
+    with pytest.raises(ts.ExportError) as excinfo:
+        ts.export_products([], [], ts.CSV_FORMAT_LABEL, str(target))
+
+    assert excinfo.value.code == ts.EXPORT_ERR_FOLDER_PREP
+    assert "підготувати теку" in excinfo.value.message

--- a/ui/app.py
+++ b/ui/app.py
@@ -1,6 +1,7 @@
 """CustomTkinter UI application for the Prom generator."""
 from __future__ import annotations
 
+import logging
 import os
 import sys
 import time
@@ -18,6 +19,7 @@ from templates_service import (
     DEFAULT_TEMPLATES,
     FILM_TYPE_DEFAULT_LABEL,
     TEMPLATE_LANGUAGE_DEFAULT_LABEL,
+    ExportError,
     export_products,
     generate_export_rows,
     get_available_export_formats,
@@ -58,6 +60,9 @@ from database import (
 )
 
 from formula_engine import FormulaEngine, FormulaError
+
+logger = logging.getLogger(__name__)
+
 
 try:
     import customtkinter as ctk
@@ -3274,9 +3279,13 @@ class App(ctk.CTk):
                 self.export_fmt_var.get(),
                 self.out_folder_var.get().strip(),
             )
-        except Exception as e:
+        except ExportError as exc:
             self._progress_reset("Помилка експорту")
-            return show_error(f"Не вдалося зберегти файли: {e}")
+            return show_error(f"Помилка експорту (код {exc.code}): {exc.message}")
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.exception("Unexpected error during export")
+            self._progress_reset("Помилка експорту")
+            return show_error(f"Не вдалося зберегти файли: {exc}")
 
         self._progress_finish(f"Готово: {len(records)} рядків")
         msg = f"✅ Згенеровано {len(records)} рядків.\nФайл експорту: {products_file}"


### PR DESCRIPTION
## Summary
- add a dedicated `ExportError` in `templates_service` and raise it with unique codes for known export failure scenarios
- update the UI export flow to show the error code to the user and log unexpected exceptions
- add unit tests covering export error codes and the UI dialog behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e26dc508ac832584eab3bd6833060a