### PR TITLE
Add import/export options for model specifications

### DIFF
--- a/specs_io.py
+++ b/specs_io.py
@@ -1,0 +1,68 @@
+"""Utilities for importing and exporting model specifications."""
+from __future__ import annotations
+
+from typing import List, Sequence, Tuple
+
+_HEADERS = {
+    "key",
+    "назва",
+    "назва параметра",
+    "характеристика",
+    "parameter",
+    "name",
+}
+
+_SEPARATORS = ("\t", ";", ",", ":", "=")
+
+
+def parse_specs_payload(raw: str) -> List[Tuple[str, str]]:
+    """Parse plain text or CSV-like payload into key/value pairs.
+
+    The parser is intentionally forgiving – it splits on a first available
+    separator and trims whitespace/quotes. Header rows with well-known column
+    names are ignored.
+    """
+
+    if not raw:
+        return []
+    text = raw.replace("\r\n", "\n").replace("\r", "\n")
+    lines = text.split("\n")
+    pairs: List[Tuple[str, str]] = []
+    first_data_row = True
+    for line in lines:
+        candidate = line.strip()
+        if not candidate:
+            continue
+        if candidate.startswith("#"):
+            # allow comments in pasted snippets
+            continue
+        key = candidate
+        value = ""
+        for separator in _SEPARATORS:
+            if separator in candidate:
+                key_part, value_part = candidate.split(separator, 1)
+                key = key_part
+                value = value_part
+                break
+        key = key.strip().strip('"').strip("'").rstrip(":;,=")
+        if not key:
+            continue
+        lower_key = key.lower()
+        if first_data_row and lower_key in _HEADERS:
+            # skip header line
+            continue
+        value = value.strip().strip('"').strip("'")
+        pairs.append((key, value))
+        first_data_row = False
+    return pairs
+
+
+def format_specs_for_clipboard(specs: Sequence[Tuple[str, str]]) -> str:
+    """Format specs into a tab-delimited string for clipboard."""
+
+    lines: List[str] = []
+    for key, value in specs:
+        safe_key = (key or "").strip()
+        safe_value = (value or "").strip()
+        lines.append(f"{safe_key}\t{safe_value}")
+    return "\n".join(lines)

--- a/tests/test_specs_io.py
+++ b/tests/test_specs_io.py
@@ -1,0 +1,30 @@
+from specs_io import format_specs_for_clipboard, parse_specs_payload
+
+
+def test_parse_specs_payload_supports_multiple_separators():
+    raw = "Вага; 1.2 кг\nКолір:\tчорний\nАкумулятор=4000 мАг"
+    assert parse_specs_payload(raw) == [
+        ("Вага", "1.2 кг"),
+        ("Колір", "чорний"),
+        ("Акумулятор", "4000 мАг"),
+    ]
+
+
+def test_parse_specs_payload_ignores_headers():
+    raw = "Назва параметра;Значення\nВага;1 кг\nКолір;Чорний"
+    assert parse_specs_payload(raw) == [("Вага", "1 кг"), ("Колір", "Чорний")]
+
+
+def test_parse_specs_payload_skips_comments_and_empty_lines():
+    raw = "# comment\n\nМатеріал корпусу: метал\n\n"
+    assert parse_specs_payload(raw) == [("Матеріал корпусу", "метал")]
+
+
+def test_format_specs_for_clipboard_builds_tab_delimited_string():
+    specs = [("Вага", "1"), ("Колір", "")]
+    assert format_specs_for_clipboard(specs) == "Вага\t1\nКолір\t"
+
+
+def test_format_specs_for_clipboard_trims_values():
+    specs = [("  Назва  ", "  Значення "), ("", None)]
+    assert format_specs_for_clipboard(specs) == "Назва\tЗначення\n\t"

--- a/ui/app.py
+++ b/ui/app.py
@@ -1,6 +1,7 @@
 """CustomTkinter UI application for the Prom generator."""
 from __future__ import annotations
 
+import csv
 import logging
 import os
 import sys
@@ -8,7 +9,7 @@ import time
 import re
 from copy import deepcopy
 from itertools import islice
-from typing import Optional
+from typing import List, Optional, Tuple
 
 import tkinter as tk
 from tkinter import filedialog, messagebox, simpledialog, ttk
@@ -66,6 +67,7 @@ from database import (
 )
 
 from formula_engine import FormulaEngine, FormulaError
+from specs_io import format_specs_for_clipboard, parse_specs_payload
 
 logger = logging.getLogger(__name__)
 
@@ -197,6 +199,37 @@ class SpecsWindow(ctk.CTkToplevel):
             command=self._delete,
         )
         self.delete_button.pack(side="left", padx=5)
+
+        bulk_ctrl = ctk.CTkFrame(self)
+        bulk_ctrl.pack(fill="x", padx=10, pady=(0, 10))
+
+        self.import_clipboard_button = ctk.CTkButton(
+            bulk_ctrl,
+            text="Імпорт з буфера",
+            command=self._import_from_clipboard,
+        )
+        self.import_clipboard_button.pack(side="left", padx=5)
+
+        self.import_file_button = ctk.CTkButton(
+            bulk_ctrl,
+            text="Імпорт з файлу",
+            command=self._import_from_file,
+        )
+        self.import_file_button.pack(side="left", padx=5)
+
+        self.export_clipboard_button = ctk.CTkButton(
+            bulk_ctrl,
+            text="Експорт у буфер",
+            command=self._export_to_clipboard,
+        )
+        self.export_clipboard_button.pack(side="left", padx=5)
+
+        self.export_file_button = ctk.CTkButton(
+            bulk_ctrl,
+            text="Експорт у файл",
+            command=self._export_to_file,
+        )
+        self.export_file_button.pack(side="left", padx=5)
 
         self._refresh()
 
@@ -442,6 +475,132 @@ class SpecsWindow(ctk.CTkToplevel):
         if button is None:
             return
         button.configure(state="normal" if enabled else "disabled")
+
+    def _collect_specs(self) -> List[Tuple[str, str]]:
+        specs: List[Tuple[str, str]] = []
+        for iid in self.tree.get_children():
+            values = self.tree.item(iid, "values")
+            if not values:
+                continue
+            key = str(values[0]).strip()
+            value = ""
+            if len(values) > 1 and values[1] is not None:
+                value = str(values[1]).strip()
+            specs.append((key, value))
+        return specs
+
+    # ------------------------------ Імпорт/експорт ---------------------------------
+
+    def _import_from_clipboard(self):
+        try:
+            raw = self.clipboard_get()
+        except tk.TclError:
+            show_error("Не вдалося прочитати буфер обміну.")
+            return
+        self._apply_import_payload(raw, source="буфера обміну")
+
+    def _import_from_file(self):
+        path = filedialog.askopenfilename(
+            title="Імпорт характеристик",
+            filetypes=(
+                ("Текстові файли", "*.txt"),
+                ("CSV/TSV", "*.csv *.tsv"),
+                ("Усі файли", "*.*"),
+            ),
+        )
+        if not path:
+            return
+        try:
+            with open(path, "r", encoding="utf-8-sig") as fh:
+                raw = fh.read()
+        except OSError as exc:
+            show_error(f"Не вдалося відкрити файл:\n{exc}")
+            return
+        self._apply_import_payload(raw, source=os.path.basename(path))
+
+    def _apply_import_payload(self, raw: str, source: str) -> None:
+        pairs = parse_specs_payload(raw)
+        if not pairs:
+            show_info("Не знайдено характеристик для імпорту.")
+            return
+        existing = {key.strip(): (sid, (value or "").strip()) for sid, key, value in get_specs(self.model_id)}
+        inserted = 0
+        updated = 0
+        skipped = 0
+        for key, value in pairs:
+            normalized_key = key.strip()
+            if not normalized_key:
+                skipped += 1
+                continue
+            normalized_value = (value or "").strip()
+            stored = existing.get(normalized_key)
+            if stored is None:
+                insert_spec(self.model_id, normalized_key, normalized_value)
+                existing[normalized_key] = (None, normalized_value)
+                inserted += 1
+                continue
+            sid, current_value = stored
+            if current_value == normalized_value:
+                skipped += 1
+                continue
+            if sid is not None:
+                update_spec(sid, normalized_key, normalized_value)
+            existing[normalized_key] = (sid, normalized_value)
+            updated += 1
+        self._refresh()
+        summary_parts = []
+        if inserted:
+            summary_parts.append(f"додано: {inserted}")
+        if updated:
+            summary_parts.append(f"оновлено: {updated}")
+        if skipped:
+            summary_parts.append(f"без змін: {skipped}")
+        if not summary_parts:
+            summary_parts.append("змін не внесено")
+        show_info(f"Імпорт завершено ({source}):\n" + ", ".join(summary_parts))
+
+    def _export_to_clipboard(self):
+        specs = self._collect_specs()
+        if not specs:
+            show_info("Немає характеристик для експорту.")
+            return
+        payload = format_specs_for_clipboard(specs)
+        try:
+            self.clipboard_clear()
+            self.clipboard_append(payload)
+        except tk.TclError:
+            show_error("Не вдалося записати дані у буфер обміну.")
+            return
+        show_info("Характеристики скопійовано до буфера обміну.")
+
+    def _export_to_file(self):
+        specs = get_specs(self.model_id)
+        if not specs:
+            show_info("Немає характеристик для експорту.")
+            return
+        path = filedialog.asksaveasfilename(
+            title="Експорт характеристик",
+            defaultextension=".csv",
+            filetypes=(
+                ("CSV файл", "*.csv"),
+                ("TSV файл", "*.tsv"),
+                ("Текстовий файл", "*.txt"),
+                ("Усі файли", "*.*"),
+            ),
+        )
+        if not path:
+            return
+        delimiter = ";" if path.lower().endswith(".csv") else "\t"
+        try:
+            with open(path, "w", newline="", encoding="utf-8") as fh:
+                writer = csv.writer(fh, delimiter=delimiter)
+                writer.writerow(["Назва параметра", "Значення"])
+                for _sid, key, value in specs:
+                    writer.writerow([key, value or ""])
+        except OSError as exc:
+            show_error(f"Не вдалося зберегти файл:\n{exc}")
+            return
+        show_info("Характеристики збережено у файл.")
 
 # ============================ GUI: ОСНОВНИЙ ДОДАТОК ============================
 


### PR DESCRIPTION
## Summary
- add clipboard and file-based import/export controls to the specifications editor
- implement reusable parsing/formatting helpers for characteristic payloads with coverage tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e57af0cba483259a8e0d2fa9f77453